### PR TITLE
Check for VIRTUAL_NETWORK first

### DIFF
--- a/volumes/proxy/templates/nginx-compose-v2.tmpl
+++ b/volumes/proxy/templates/nginx-compose-v2.tmpl
@@ -77,20 +77,21 @@ upstream {{ $host }} {
 {{ range $index, $value := $containers }}
 
     {{ $addrLen := len $value.Addresses }}
-    {{/* If only 1 port exposed, use that */}}
-    {{ if eq $addrLen 1 }}
-        {{ with $address := index $value.Addresses 0 }}
-           # {{$value.Name}}
-           server {{ $address.IP }}:{{ $address.Port }};
-        {{ end }}
 
     {{/* If a VIRTUAL_NETWORK is specified use use its IP */}}
-    {{ else if $value.Env.VIRTUAL_NETWORK }}
+    {{ if $value.Env.VIRTUAL_NETWORK }}
         {{ range $i, $network := $value.Networks }}
            {{ if eq $network.Name $value.Env.VIRTUAL_NETWORK }}
    # Container: {{$value.Name}}@{{$network.Name}}
    server {{ $network.IP }}:{{ $value.Env.VIRTUAL_PORT }};
            {{ end }}
+        {{ end }}
+
+    {{/* If only 1 port exposed, use that */}}
+    {{ else if eq $addrLen 1 }}
+        {{ with $address := index $value.Addresses 0 }}
+           # {{$value.Name}}
+           server {{ $address.IP }}:{{ $address.Port }};
         {{ end }}
 
     {{/* If more than one port exposed, use the one matching VIRTUAL_PORT env var */}}


### PR DESCRIPTION
It seems to be the right order of checks.

I've found this having a container with a single address ON a virtual network (compose v2), which resulted in invalid nginx config (empty `$address.IP`).
