### PR TITLE
nx-webxy 

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-cayman


### PR DESCRIPTION
### **docker-compose was the better way .**

$ git clone https://github.com/forrest419/nx-webxy.git

$ cd nx-webxy

    docker run commod or docker-compose

1st way:  docker ### **run**

**Replace all the default "site.example.com" and "mail@example.com" occurrences in docker-run/simple-site/docker-run.sh for your publicly accessible domain redirecting to the server running the script.**
$ ./docker-run.sh

**将 docker-run/simple-site/docker-run.sh 中所有示例网域及邮件地址“site.example.com” ，“mail@example.com”替换为您解析过可用的公网可访问地址或者重定向到运行脚本的服务器。**
运行命令    $ ./docker-run.sh

2nd way: ### **docker-compose**

While docker-compose v1 file version isn't advised for starting new project, docker-gen hasn't yet officially resolved the issue raised by new networking in docker-compose v2, you might find it easier to stick with v1.

Replace all the default "site.example.com" and "mail@example.com" occurrences in docker-compose/v1/simple-site/docker-compose.yml for your publicly accessible domain redirecting to the server running the script.

  $ docker-compose up


docker-compose v1文件版本是基础项目版本，但是docker-gen尚未正式解决docker-compose v2中新网络引发的问题，您会发现个人使用v1更简单实用。两个文件的修改方法都只是docker-compose.yml中的所有示例的“site.example.com”和“mail@example.com”替换为您解析过，可使用的公网可访问地址，或重定向到运行该脚本的服务器。

  $ docker-compose up
 
v2则需要多一个步骤，创建一个名为'nginx-proxy'的外部网络

$ docker network -d bridge nginx-proxy

你也可以docker-compose文件内的默认网络名称修改为'nginx-proxy'

$ docker-compose up

